### PR TITLE
address seems to be its own noun, with its own properties

### DIFF
--- a/sample/sample_digitized_audioanalogcassette.json
+++ b/sample/sample_digitized_audioanalogcassette.json
@@ -118,11 +118,13 @@
 		},
 		"organization": {
 			"name": "Organization XYZ",
-			"addressStreet1": "123 ABC St",
-			"addressStreet2": "Suite 1234",
-			"addressCity": "Anytown",
-			"addressState": "ST",
-			"addressPostalCode": 12345
+      "address": {
+        "street1": "123 ABC St",
+        "street2": "Suite 1234",
+        "city":    "Anytown",
+        "state":   "ST",
+        "postalCode": "12345"
+      }
 		}
 	}
 }

--- a/sample/sample_digitized_audiodigitalcassette.json
+++ b/sample/sample_digitized_audiodigitalcassette.json
@@ -106,11 +106,13 @@
 		},
 		"organization": {
 			"name": "Organization XYZ",
-			"addressStreet1": "123 ABC St",
-			"addressStreet2": "Suite 1234",
-			"addressCity": "Anytown",
-			"addressState": "ST",
-			"addressPostalCode": 12345
+      "address": {
+        "street1": "123 ABC St",
+        "street2": "Suite 1234",
+        "city":    "Anytown",
+        "state":   "ST",
+        "postalCode": "12345"
+      }
 		}
 	}
 }

--- a/sample/sample_digitized_audiooptical.json
+++ b/sample/sample_digitized_audiooptical.json
@@ -84,11 +84,13 @@
 		},
 		"organization": {
 			"name": "Organization XYZ",
-			"addressStreet1": "123 ABC St",
-			"addressStreet2": "Suite 1234",
-			"addressCity": "Anytown",
-			"addressState": "ST",
-			"addressPostalCode": 12345
+      "address": {
+        "street1": "123 ABC St",
+        "street2": "Suite 1234",
+        "city":    "Anytown",
+        "state":   "ST",
+        "postalCode": "12345"
+      }
 		}
 	}
 }

--- a/sample/sample_digitized_audioreel.json
+++ b/sample/sample_digitized_audioreel.json
@@ -122,11 +122,13 @@
 		},
 		"organization": {
 			"name": "Organization XYZ",
-			"addressStreet1": "123 ABC St",
-			"addressStreet2": "Suite 1234",
-			"addressCity": "Anytown",
-			"addressState": "ST",
-			"addressPostalCode": 12345
+      "address": {
+        "street1": "123 ABC St",
+        "street2": "Suite 1234",
+        "city":    "Anytown",
+        "state":   "ST",
+        "postalCode": "12345"
+      }
 		}
 	}
 }

--- a/sample/sample_digitized_videocassette.json
+++ b/sample/sample_digitized_videocassette.json
@@ -109,11 +109,13 @@
 		},
 		"organization": {
 			"name": "Organization XYZ",
-			"addressStreet1": "123 ABC St",
-			"addressStreet2": "Suite 1234",
-			"addressCity": "Anytown",
-			"addressState": "ST",
-			"addressPostalCode": 12345
+      "address": {
+        "street1": "123 ABC St",
+        "street2": "Suite 1234",
+        "city":    "Anytown",
+        "state":   "ST",
+        "postalCode": "12345"
+      }
 		}
 	}
 }

--- a/sample/sample_digitized_videooptical.json
+++ b/sample/sample_digitized_videooptical.json
@@ -93,11 +93,13 @@
 		},
 		"organization": {
 			"name": "Organization XYZ",
-			"addressStreet1": "123 ABC St",
-			"addressStreet2": "Suite 1234",
-			"addressCity": "Anytown",
-			"addressState": "ST",
-			"addressPostalCode": 12345
+      "address": {
+        "street1": "123 ABC St",
+        "street2": "Suite 1234",
+        "city":    "Anytown",
+        "state":   "ST",
+        "postalCode": "12345"
+      }
 		}
 	}
 }

--- a/sample/sample_digitized_videoreel.json
+++ b/sample/sample_digitized_videoreel.json
@@ -117,11 +117,13 @@
 		},
 		"organization": {
 			"name": "Organization XYZ",
-			"addressStreet1": "123 ABC St",
-			"addressStreet2": "Suite 1234",
-			"addressCity": "Anytown",
-			"addressState": "ST",
-			"addressPostalCode": 12345
+      "address": {
+        "street1": "123 ABC St",
+        "street2": "Suite 1234",
+        "city":    "Anytown",
+        "state":   "ST",
+        "postalCode": "12345"
+      }
 		}
 	}
 }

--- a/schema/fields.json
+++ b/schema/fields.json
@@ -347,30 +347,36 @@
           "additionalItems": false,
           "required": [
             "name",
-            "addressStreet1",
-            "addressCity",
-            "addressState",
-            "addressPostalCode"
+            "address"
           ],
           "properties": {
             "name": {
               "type": "string"
             },
-            "addressStreet1": {
-              "type": "string"
-            },
-            "addressStreet2": {
-              "type": "string"
-            },
-            "addressCity": {
-              "type": "string"
-            },
-            "addressState": {
-              "type": "string",
-              "pattern": "^[A-Z]{2}$"
-            },
-            "addressPostalCode": {
-              "type": ["number", "string"]
+            "address": {
+              "type": "object",
+              "required": [
+                "street1",
+                "city",
+                "state",
+                "postalCode"
+              ],
+              "street1":  {
+                "type": "string"
+              },
+              "street2":  {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state":  {
+                "type": "string",
+                "pattern":  "^[A-Z]{2}$"
+              },
+              "postalCode": {
+                "type": "string"
+              }
             }
           }
         }


### PR DESCRIPTION
Seeing "address" prefixed in so many property names is a good indication that this prefix in quesiton is its own object - with its own properties.

Note that I change postalCode to a string in this PR...so if you accept this PR
you can just close https://github.com/NYPL/ami-metadata/pull/1.

