### PR TITLE
Revert "US Zip codes look like numbers but aren't very number-like"

### DIFF
--- a/sample/sample_digitized_audioanalogcassette.json
+++ b/sample/sample_digitized_audioanalogcassette.json
@@ -122,7 +122,7 @@
 			"addressStreet2": "Suite 1234",
 			"addressCity": "Anytown",
 			"addressState": "ST",
-			"addressPostalCode": "12345"
+			"addressPostalCode": 12345
 		}
 	}
 }

--- a/sample/sample_digitized_audiodigitalcassette.json
+++ b/sample/sample_digitized_audiodigitalcassette.json
@@ -110,7 +110,7 @@
 			"addressStreet2": "Suite 1234",
 			"addressCity": "Anytown",
 			"addressState": "ST",
-			"addressPostalCode": "12345"
+			"addressPostalCode": 12345
 		}
 	}
 }

--- a/sample/sample_digitized_audiooptical.json
+++ b/sample/sample_digitized_audiooptical.json
@@ -88,7 +88,7 @@
 			"addressStreet2": "Suite 1234",
 			"addressCity": "Anytown",
 			"addressState": "ST",
-			"addressPostalCode": "12345"
+			"addressPostalCode": 12345
 		}
 	}
 }

--- a/sample/sample_digitized_audioreel.json
+++ b/sample/sample_digitized_audioreel.json
@@ -126,7 +126,7 @@
 			"addressStreet2": "Suite 1234",
 			"addressCity": "Anytown",
 			"addressState": "ST",
-			"addressPostalCode": "12345"
+			"addressPostalCode": 12345
 		}
 	}
 }

--- a/sample/sample_digitized_videocassette.json
+++ b/sample/sample_digitized_videocassette.json
@@ -113,7 +113,7 @@
 			"addressStreet2": "Suite 1234",
 			"addressCity": "Anytown",
 			"addressState": "ST",
-			"addressPostalCode": "12345"
+			"addressPostalCode": 12345
 		}
 	}
 }

--- a/sample/sample_digitized_videooptical.json
+++ b/sample/sample_digitized_videooptical.json
@@ -97,7 +97,7 @@
 			"addressStreet2": "Suite 1234",
 			"addressCity": "Anytown",
 			"addressState": "ST",
-			"addressPostalCode": "12345"
+			"addressPostalCode": 12345
 		}
 	}
 }

--- a/sample/sample_digitized_videoreel.json
+++ b/sample/sample_digitized_videoreel.json
@@ -121,7 +121,7 @@
 			"addressStreet2": "Suite 1234",
 			"addressCity": "Anytown",
 			"addressState": "ST",
-			"addressPostalCode": "12345"
+			"addressPostalCode": 12345
 		}
 	}
 }

--- a/schema/fields.json
+++ b/schema/fields.json
@@ -370,7 +370,7 @@
               "pattern": "^[A-Z]{2}$"
             },
             "addressPostalCode": {
-              "type": "string"
+              "type": ["number", "string"]
             }
           }
         }


### PR DESCRIPTION
Reverts NYPL/ami-metadata#1, it is superseded by NYPL/ami-metadata#2