### PR TITLE
update grooved disc base and surface materials

### DIFF
--- a/versions/2.0/schema/digitized_audiogrooveddisc.json
+++ b/versions/2.0/schema/digitized_audiogrooveddisc.json
@@ -167,6 +167,7 @@
                 "paper",
                 "nickel-plated copper",
                 "zinc",
+                "wood",
                 "unknown metal"
               ]
             },
@@ -176,6 +177,7 @@
                 "cellulose nitrate",
                 "celluloid",
                 "gelatin",
+                "vinyl",
                 "none",
                 "unknown"
               ]


### PR DESCRIPTION
added "wood," for base of Edison Diamond Discs; added "vinyl" for surface material of vinyls