### PR TITLE
allow negative numeric value for shrinkage (stretch)

### DIFF
--- a/versions/2.0/sample/sample_digitized_motionpicturefilm.json
+++ b/versions/2.0/sample/sample_digitized_motionpicturefilm.json
@@ -61,7 +61,7 @@
 			"conditionPerforationDamage": 3,
 			"conditionDistortion": 3,
 			"shrinkage": {
-				"measure": 1.5,
+				"measure": -1.0,
 				"unit": "%"
 			}
 		},

--- a/versions/2.0/schema/digitized_motionpicturefilm.json
+++ b/versions/2.0/schema/digitized_motionpicturefilm.json
@@ -209,8 +209,7 @@
               "properties": {
                 "measure": {
                   "type": "number",
-                  "multipleOf": 0.01,
-                  "minimum": 0.01
+                  "minimum": -1.0
                 },
                 "unit": {
                   "enum": [


### PR DESCRIPTION
removed 'multipleOf' validation keyword for shrinkage, replaced with 'minimum'.