### PR TITLE
change phono cartridge measure to string

### DIFF
--- a/versions/2.0/schema/fields.json
+++ b/versions/2.0/schema/fields.json
@@ -464,7 +464,7 @@
                   ],
                   "properties": {
                     "measure": {
-                      "type": "number"
+                      "type": "string"
                     },
                     "unit": {
                       "enum": [


### PR DESCRIPTION
from number, to allow for unusual phono cartridges w/ measures like ".008 x .004"